### PR TITLE
expressのデフォルトのポート番号を5000に変更

### DIFF
--- a/Server/bin/www
+++ b/Server/bin/www
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(process.env.PORT || '5000');
 app.set('port', port);
 
 /**


### PR DESCRIPTION
# 変更内容
espressのデフォルトのポート番号を3000→5000に変更しました。